### PR TITLE
fix(readme): update version even if no operator is present

### DIFF
--- a/lib/helpers/regexes/readme.regexes.js
+++ b/lib/helpers/regexes/readme.regexes.js
@@ -9,7 +9,7 @@ export function createReadmeVersionRequirementRegexs(projectName) {
   const readmeVersionRegexesArray = [
     composeMixDepsSemVerRegex(
       projectName,
-      /.*"\s*(?:>|>=|<|<=|==|!=|~>)\s*/,
+      /.*"\s*(?:>|>=|<|<=|==|!=|~>)?\s*/,
       /"/,
       true,
     ),

--- a/lib/helpers/regexes/readme.regexes.spec.js
+++ b/lib/helpers/regexes/readme.regexes.spec.js
@@ -29,7 +29,7 @@ describe("readmeVersionRegex", () => {
     const { readmeVersionRegex } =
       createReadmeVersionRequirementRegexs("test_package");
 
-    const operators = [">", ">=", "<", "<=", "==", "!=", "~>"];
+    const operators = ["", ">", ">=", "<", "<=", "==", "!=", "~>"];
 
     expect.assertions(validSemVers.length * operators.length);
     for (let semVer of validSemVers) {

--- a/tests/fixtures/readme/readme-no-operator.md
+++ b/tests/fixtures/readme/readme-no-operator.md
@@ -1,0 +1,9 @@
+# Hello World
+
+## Installation
+
+```elixir
+def deps do
+  [{:hello_world, "{{VERSION}}"}]
+end
+```

--- a/tests/helpers/create-test-project.js
+++ b/tests/helpers/create-test-project.js
@@ -22,7 +22,7 @@ import { temporaryDirectory } from "tempy";
  * @param {boolean | null} [asAttribute] (mix.exs) whether to set the version as a module attribute
  * @param {"trap" | "complex-name" | null} [mixSuffix] (mix.exs) optional mix fixture file suffix
  * @param {boolean | null} [asGitTag] (README.md) whether to set the version as a git tag
- * @param {"empty" | null} [gitOverride] (README.md) override for the filename suffix
+ * @param {"empty" | "no-operator" | null} [gitOverride] (README.md) override for the filename suffix
  * @returns {Project}
  */
 export function createTestProject(

--- a/tests/prepare.test.js
+++ b/tests/prepare.test.js
@@ -153,14 +153,27 @@ describe("prepare step", () => {
    */
 
   describe("update README.md", () => {
+    // eslint-disable-next-line jest/prefer-expect-assertions
     it("should update project version", async () => {
-      expect.assertions(6);
+      const configs = [
+        { asGitTag: false },
+        { asGitTag: true },
+        { override: "no-operator" },
+      ];
 
-      for (let asGitTag of [false, true]) {
+      expect.assertions(configs.length * 3);
+      for (let { asGitTag, override } of configs) {
         const {
           cwd,
           readme: { path },
-        } = createTestProject("0.0.0-dev", null, null, asGitTag);
+        } = createTestProject(
+          "0.0.0-dev",
+          null,
+          null,
+          asGitTag,
+          // @ts-ignore
+          override,
+        );
 
         await prepare(
           {},

--- a/tests/prepare.test.js
+++ b/tests/prepare.test.js
@@ -184,15 +184,15 @@ describe("prepare step", () => {
           },
         );
 
-        const packageContent = fs.readFileSync(path, { encoding: "utf-8" });
-
+        const readmeContent = fs.readFileSync(path, { encoding: "utf-8" });
+        console.debug(readmeContent);
         const { readmeVersionRegex, readmeVersionRegexesArray } =
           createReadmeVersionRequirementRegexs("hello_world");
 
-        expect(packageContent).toMatch(readmeVersionRegex);
-        expect(packageContent).not.toMatch(/0\.0\.0-dev/);
+        expect(readmeContent).toMatch(readmeVersionRegex);
+        expect(readmeContent).not.toMatch(/0\.0\.0-dev/);
         const { version } = readVersion(
-          packageContent,
+          readmeContent,
           readmeVersionRegexesArray,
         );
         expect(version).toBe("1.0.0");
@@ -239,8 +239,8 @@ describe("prepare step", () => {
           },
         );
 
-        const packageContent = fs.readFileSync(path, { encoding: "utf-8" });
-        expect(packageContent).toBe(
+        const readmeContent = fs.readFileSync(path, { encoding: "utf-8" });
+        expect(readmeContent).toBe(
           content.replace("0.0.0-tobereplaced", "1.0.0"),
         );
       }

--- a/tests/prepare.test.js
+++ b/tests/prepare.test.js
@@ -67,28 +67,6 @@ describe("prepare step", () => {
       }
     });
 
-    it("should ignore empty README ang call the logger with the cwd", async () => {
-      expect.assertions(2);
-
-      const { cwd } = createTestProject("0.0.0-dev", null, null, null, "empty");
-
-      await expect(
-        prepare(
-          {},
-          {
-            ...context,
-            cwd,
-            nextRelease: { version: "1.0.0" },
-          },
-        ),
-      ).resolves.not.toThrow();
-
-      expect(context.logger.log).toHaveBeenCalledWith(
-        "No version found in README.md in %s",
-        cwd,
-      );
-    });
-
     it("should not update the version outside of the project definition", async () => {
       expect.assertions(10);
 
@@ -206,6 +184,28 @@ describe("prepare step", () => {
         );
         expect(version).toBe("1.0.0");
       }
+    });
+
+    it("should ignore empty README and call the logger with the cwd", async () => {
+      expect.assertions(2);
+
+      const { cwd } = createTestProject("0.0.0-dev", null, null, null, "empty");
+
+      await expect(
+        prepare(
+          {},
+          {
+            ...context,
+            cwd,
+            nextRelease: { version: "1.0.0" },
+          },
+        ),
+      ).resolves.not.toThrow();
+
+      expect(context.logger.log).toHaveBeenCalledWith(
+        "No version found in README.md in %s",
+        cwd,
+      );
     });
 
     it("should preserve indentation and newline", async () => {


### PR DESCRIPTION
Pinned versions in README weren't updating.
This makes the requirement operator optional in the regular (hex) readme regex.